### PR TITLE
Use fallocate to pre-allocate space

### DIFF
--- a/src/hydra.py
+++ b/src/hydra.py
@@ -41,15 +41,16 @@ def WritingBloomFilter(num_elements, max_fp_prob, filename=None,
     (num_elements, max_fp_prob) as a specification and using filename
     as the backing datastore.
     """
+    new_filter = _hydra.BloomFilter.getFilter(
+        num_elements, max_fp_prob,
+        filename=filename, ignore_case=ignore_case,
+        read_only=False, want_lock=want_lock)
     if filename:
         with open('{}.desc'.format(filename), 'w') as descriptor:
             descriptor.write("{}\n".format(num_elements))
             descriptor.write("{:0.8f}\n".format(max_fp_prob))
             descriptor.write("{:d}\n".format(ignore_case))
-    return _hydra.BloomFilter.getFilter(
-        num_elements, max_fp_prob,
-        filename=filename, ignore_case=ignore_case,
-        read_only=False, want_lock=want_lock)
+    return new_filter
 
 # Expose the murmur hash
 murmur_hash = _hydra.hash

--- a/src/mmap_writer.c
+++ b/src/mmap_writer.c
@@ -38,6 +38,7 @@ int open_mmap_file_rw(char* filename, size_t bytesize)
          return -1;
     }
 
+#ifdef __linux__
     /* Stretch the file size to the size of the (mmapped) array of
      * ints
      * */
@@ -49,6 +50,39 @@ int open_mmap_file_rw(char* filename, size_t bytesize)
         close(fd);
         return -1;
     }
+#else
+    /* Stretch the file size to the size of the (mmapped) array of
+     * ints
+     * */
+    result = lseek(fd, bytesize-1, SEEK_SET);
+    if (result == -1) {
+        PyErr_SetFromErrnoWithFilename(PyExc_OSError,
+                           "Error calling lseek() to 'stretch' the file");
+        close(fd);
+         return -1;
+    }
+
+    /* Something needs to be written at the end of the file to
+     * * have the file actually have the new size.
+     * * Just writing an empty string at the current file position
+     * will do.
+     * *
+     * * Note:
+     * * - The current position in the file is at the end of the
+     * stretched
+     * * file due to the call to lseek().
+     * * - An empty string is actually a single '\0' character, so a
+     * zero-byte
+     * * will be written at the last byte of the file.
+     * */
+    result = write(fd, "", 1);
+    if (result != 1) {
+        close(fd);
+        PyErr_SetFromErrnoWithFilename(PyExc_OSError,
+                           "Error writing last byte of the file");
+         return -1;
+    }
+#endif
 
     return fd;
 }


### PR DESCRIPTION
The current method of file allocation does not pre-allocate any disk space.  You end up with a very fragmented file after adding entries.

We could revisit this and add another parameter, "want_sparse" if we don't want to always allocate dense files.
