### PR TITLE
Test against Python 3.5 on Travis.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ _hydra.c
 *.so
 *.swp
 *egg-info
+bin
 build
 dist
+include
 javabloom
+lib
+man

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
+# new container based environment
+sudo: false
+
+cache:
+  pip: true
+
 language: python
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
 install:
-  - "pip install Cython"
   - "pip install -r requirements.txt"
 script:
   - "python setup.py build_ext --inplace"

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ from os.path import join
 
 import os
 
+__version__ = '2.4.dev0'
+
 ext_modules = [Extension("_hydra",
                          extra_compile_args=['-std=gnu99',
                                              '-O2',
@@ -24,11 +26,22 @@ setup(name='Hydra',
       author_email='crankycoder@gmail.com',
       description='A high performance persistent bloom filter',
       url="http://github.com/crankycoder/Hydra",
-      version='2.2',
+      version=__version__,
       license='MIT License',
       cmdclass={'build_ext': build_ext},
       zip_safe=False,
       package_dir={'': 'src'},
       py_modules=['hydra'],
       ext_modules=ext_modules,
-      test_suite='nose.collector')
+      test_suite='nose.collector',
+      classifiers=[
+          'License :: OSI Approved :: MIT License',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: Implementation :: CPython',
+      ],
+)


### PR DESCRIPTION
Update Travis to use new container based infrastructure and use its pip cache. Remove manual `pip install Cython`, as it's part of `requirements.txt`. Also add Trove classifiers and correct version to 2.4.dev0 as there was a 2.3 release.
